### PR TITLE
Suppression du 1er et dernier caractére si ce sont des guillemets.

### DIFF
--- a/core/class/virtual.class.php
+++ b/core/class/virtual.class.php
@@ -313,7 +313,7 @@ class virtualCmd extends cmd {
 				try {
 					$result = jeedom::evaluateExpression($this->getConfiguration('calcul'));
 					if(is_string($result)){
-						$result = str_replace('"', '', $result);
+						preg_replace('/^"|"$/', '', $result);
 					}
 					$this->event($result);
 					return $result;


### PR DESCRIPTION
Pourquoi supprimer tous les guillemets dans une chaine de caractères ?
Le navigateur a du mal à reconstruire un style à partir d'un texte sans guillemet.
Quand à la liste des points d'un polygone en svg, c'est impossible.

Le monologue qui me fait faire ce PR est là:
https://community.jeedom.com/t/probleme-daffichage-html-ou-svg-dans-un-virtuel/26323?u=jpty